### PR TITLE
Fix ParseElementalDamage()

### DIFF
--- a/POE-ItemInfo.ahk
+++ b/POE-ItemInfo.ahk
@@ -630,6 +630,12 @@ ParseElementalDamage(String, DmgType, ByRef DmgLo, ByRef DmgHi)
         {
             return
         }
+		IfInString, String, Damage to Spells
+        {
+		    StringSplit, Arr, String, %A_Space%
+            StringSplit, Arr, Arr2, -
+            return Arr1+Arr2
+        }
         IfNotInString, String, increased 
         {
             StringSplit, Arr, String, %A_Space%


### PR DESCRIPTION
Fix for counting elem DPS.
Avoid using %DmgType% Damage to Spells affixes.